### PR TITLE
Exclude API from Stronghold

### DIFF
--- a/statuspage/settings.py
+++ b/statuspage/settings.py
@@ -107,6 +107,9 @@ MIDDLEWARE = [
 ]
 
 STRONGHOLD_DEFAULTS = True
+STRONGHOLD_PUBLIC_URLS = (
+    r'^/api/',
+)
 
 ROOT_URLCONF = 'statuspage.urls'
 


### PR DESCRIPTION
Given that all API views already require an API key in order to operate, requiring the extra layer of authentication that Stronghold adds is extraneous and, at times, problematic.

This PR adds an exclusion to Stronghold for all API routes, allowing them to be accessed without trying to redirect to the login page.