### PR TITLE
Changed logout url/link to work for non 'staff' users

### DIFF
--- a/status/templates/status/partials/menu.html
+++ b/status/templates/status/partials/menu.html
@@ -6,6 +6,6 @@
         <A HREF="{% url 'status:dashboard' %}" class="btn btn-primary"><i class="fa fa-list"></i> Incidents</A>
         <A HREF="{% url 'status:dashboard_hidden' %}" class="btn btn-primary"><i class="fa fa-eye"></i> Hidden Incidents</A>
         <A HREF="{% url 'admin:auth_user_changelist' %}" class="btn btn-primary"><i class="fa fa-users"></i> Users</A>
-        <A HREF="{% url 'admin:logout' %}?next=/" class="btn btn-primary"><i class="fa fa-sign-out"></i> Sign Out</A>
+        <A HREF="{% url 'logout' %}?next=/" class="btn btn-primary"><i class="fa fa-sign-out"></i> Sign Out</A>
     </div>
 {% endif %}

--- a/statuspage/urls.py
+++ b/statuspage/urls.py
@@ -11,7 +11,7 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^', include('status.urls', namespace='status', app_name='status')),
     url(r'^account/login/$', login, {'template_name': 'admin/login.html'}, 'login'),
-    url(r'^account/logout/$', logout, 'logout'),
+    url(r'^account/logout/$', logout, {'template_name': 'admin/logout.html'}, 'logout'),
     url(r'^avatar/', include('avatar.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),


### PR DESCRIPTION
if the user account isn't a "staff" user (has access to the /admin dashboard) the admin/logout url is inaccessible to them. This points at the standard user logout url instead.